### PR TITLE
Use own docker image with prebuilt grpcio version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run tests and build docker image
 
 on: [push]
 
@@ -6,10 +6,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine3.13
+FROM jjst/alpine-python-grpcio:3.13-python3.9-grpcio-1.30.0-r1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -6,9 +6,7 @@ WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app/
 
 # Required to build grpcio
-RUN apk add g++ linux-headers && \
-    echo 'manylinux1_compatible = True' > /usr/local/lib/python3.9/site-packages/_manylinux.py && \
-    pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jjst/alpine-python-grpcio:3.13-python3.9-grpcio-1.30.0-r1
+FROM jjst/alpine-python-grpcio:3.13-python3.9-grpcio-1.38.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ isodate==0.6.0
 itsdangerous==2.0.1
 Jinja2==3.0.1
 jsonschema==3.2.0
+grpcio==1.38.0
 MarkupSafe==2.0.1
 openapi-schema-validator==0.1.5
 openapi-spec-validator==0.3.1


### PR DESCRIPTION
grpcio takes ages to compile on alpine, so prebuild it in a separate docker img
