### PR TITLE
Fix gunicorn worker dir on digital ocean...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ EXPOSE 8080
 
 ENTRYPOINT ["gunicorn"]
 
-CMD ["--access-logfile=-", "--bind", "0.0.0.0:8080", "api:app"]
+CMD ["--access-logfile=-", "--bind", "0.0.0.0:8080", "--worker-tmp-dir", "/dev/shm", "api:app"]


### PR DESCRIPTION
See:
* https://www.roelpeters.be/permissionerror-errno-1-operation-not-permitted/
* https://www.digitalocean.com/community/tutorials/how-to-deploy-django-to-app-platform