### PR TITLE
Clean up station controller <-> config ...

### DIFF
--- a/src/base/stations.py
+++ b/src/base/stations.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+import itertools
+from typing import Any, Optional
+
+from base.config import settings
+
+
+@dataclass
+class RadioStationInfo:
+    id: str
+    country_code: str
+    name: str
+    favicon: Optional[str]
+    streams: list[Any]
+
+
+def get_all(namespace: Optional[str] = None) -> list[RadioStationInfo]:
+    def stations_in_namespace(ns):
+        items = []
+        for station_id, data in settings.get("stations")[ns].items():
+            items.append(_build_station_info(data, station_id, namespace))
+        return items
+    if namespace:
+        return stations_in_namespace(namespace)
+    else:
+        return itertools.chain(stations_in_namespace(ns) for ns in settings.get("stations"))
+
+
+def get(namespace: str, id: str) -> RadioStationInfo:
+    data = settings["stations"][namespace][id]
+    return _build_station_info(data, id, namespace)
+
+
+def _build_station_info(station, station_id, country_code):
+    station_name = station['name']
+    streams = [s for s in station.get('streams', [])]
+    favicon = station.get('favicon')
+    radio_station = RadioStationInfo(
+        id=station_id,
+        country_code=country_code,
+        name=station_name,
+        favicon=favicon,
+        streams=streams
+    )
+    return radio_station


### PR DESCRIPTION
Introduce stations module used to serve stations from data, called from
stations controller.

Left to do - wire the aggregator module to this somehow too, so that
aggregator config can be changed live correctly.

Fixes issue causing stations to be reloaded from fresh config files at each API call, causing performance degradation on `/stations/:country_code` endpoint.