### PR TITLE
Save to s3 for jsonpath aggregator

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,0 +1,4 @@
+s3:
+  enabled: True
+  endpoint_url: s3.eu-central-1.wasabisys.com
+  bucket_name: now-playing-aggregated-data

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,4 +1,4 @@
 s3:
   enabled: True
-  endpoint_url: s3.eu-central-1.wasabisys.com
+  endpoint_url: https://s3.eu-central-1.wasabisys.com
   bucket_name: now-playing-aggregated-data

--- a/conf/stations/fr/misc.yaml
+++ b/conf/stations/fr/misc.yaml
@@ -6,6 +6,7 @@ stations:
         now-playing:
           - module: jsonpath_aggregator
             params:
+              station_id:
               url: "https://www.cheriefm.fr/onair"
               field_extractors:
                 artist: '$.[?(@.id == "190")].playlist[?(@.id != 0)].song.artist'

--- a/conf/stations/ie/spin1038.yaml
+++ b/conf/stations/ie/spin1038.yaml
@@ -6,6 +6,7 @@ stations:
         now-playing:
           - module: jsonpath_aggregator
             params:
+              station_id:
               url: "https://s3-eu-west-1.amazonaws.com/storage.publisherplus.ie/media.radiocms.net/now-playing/spin1038"
               field_extractors:
                 artist: '$.artist'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ APScheduler==3.7.0
 asgiref==3.3.4
 attrs==21.2.0
 backoff==1.10.0
+boto3==1.17.101
+botocore==1.20.101
 certifi==2021.5.30
 chardet==4.0.0
 click==8.0.1
@@ -22,6 +24,7 @@ inflection==0.5.1
 isodate==0.6.0
 itsdangerous==2.0.1
 Jinja2==3.0.1
+jmespath==0.10.0
 jsonpath-ng==1.5.2
 jsonschema==3.2.0
 lark-parser==0.7.8
@@ -33,6 +36,8 @@ opentelemetry-api==1.3.0
 opentelemetry-exporter-otlp==1.3.0
 opentelemetry-exporter-otlp-proto-grpc==1.3.0
 opentelemetry-instrumentation==0.22b0
+opentelemetry-instrumentation-boto==0.22b0
+opentelemetry-instrumentation-botocore==0.22b0
 opentelemetry-instrumentation-flask==0.22b0
 opentelemetry-instrumentation-requests==0.22b0
 opentelemetry-instrumentation-urllib==0.22b0
@@ -52,6 +57,7 @@ pytz==2021.1
 PyYAML==5.4.1
 requests==2.25.1
 requests-cache==0.6.4
+s3transfer==0.4.2
 six==1.16.0
 streamscrobbler @ git+https://github.com/Horrendus/streamscrobbler-python@ec8fd4e1549b7cba25833950aa565b17700453e0
 swagger-spec-validator==2.7.3

--- a/src/aggregators/__init__.py
+++ b/src/aggregators/__init__.py
@@ -36,11 +36,23 @@ def load_aggregators():
     return aggregators
 
 
-def _with_default_params(params: dict, country_code: str, station_id: str) -> dict:
+def _with_default_params(params: dict, namespace: str, slug: str) -> dict:
+    """
+    Support for default parameters. Some aggregator parameters don't need to
+    have a value specified, they indicate the aggregator wants to get existing
+    information from the station it's aggregating data for.
+    """
+    # TODO: I'm not actually sure I want to keep this feature as-is.
+    # Leaning towards always providing station info as a param to fetch() instead.
     if 'country_code' in params:
-        params['country_code'] = country_code
+        # Legacy attr name
+        params['country_code'] = namespace
+    if 'namespace' in params:
+        params['namespace'] = namespace
+    if 'slug' in params:
+        params['slug'] = slug
     if 'station_id' in params:
-        params['station_id'] = station_id
+        params['station_id'] = f"{namespace}/{slug}"
     return params
 
 

--- a/src/aggregators/fip.py
+++ b/src/aggregators/fip.py
@@ -1,16 +1,17 @@
 from string import Template
 from aggregators import PlayingItem
 
+# FIXME: pass these ids as config values straight from the config file
 stations = {
-    'fip': 7,
-    'fip-rock': 64,
-    'fip-jazz': 65,
-    'fip-groove': 66,
-    'fip-pop': 78,
-    'fip-electro': 74,
-    'fip-monde': 69,
-    'fip-reggae': 71,
-    'fip-nouveautes': 70
+    'fr/fip': 7,
+    'fr/fip-rock': 64,
+    'fr/fip-jazz': 65,
+    'fr/fip-groove': 66,
+    'fr/fip-pop': 78,
+    'fr/fip-electro': 74,
+    'fr/fip-monde': 69,
+    'fr/fip-reggae': 71,
+    'fr/fip-nouveautes': 70
 }
 persisted_query_hash = "151ca055b816d28507dae07f9c036c02031ed54e18defc3d16feee2551e9a731"
 

--- a/src/aggregators/france_bleu.py
+++ b/src/aggregators/france_bleu.py
@@ -4,6 +4,6 @@ base_url = "https://www.francebleu.fr/grid"
 
 
 def fetch(session, request_type, station_id):
-    location = station_id.removeprefix('france-bleu-')  # bit hackish but eh
+    location = station_id.removeprefix('fr/france-bleu-')  # bit hackish but eh
     url = f"{base_url}/{location}"
     return france_inter.fetch_url(session, url)

--- a/src/aggregators/jsonpath_aggregator.py
+++ b/src/aggregators/jsonpath_aggregator.py
@@ -1,11 +1,11 @@
 import boto3
+import botocore.exceptions
 from jsonpath_ng.ext import parse
 import commentjson
 import json
 from json.decoder import JSONDecodeError
 import pprint
 import logging
-from urllib.parse import urlparse
 import time
 
 from base.config import settings
@@ -18,15 +18,18 @@ DEFAULT_ENGINE = PYTHON_JSONPATH_NG_EXT
 JAVA_JSONPATH_API_URL = "https://java-jsonpath-api-bknua.ondigitalocean.app/"
 
 
-def fetch(session, request_type: str, url: str, field_extractors: dict, format_string: str, engine: str = DEFAULT_ENGINE):
+def fetch(session, request_type: str, station_id: str, url: str, field_extractors: dict, format_string: str, engine: str = DEFAULT_ENGINE):
+    print(station_id)
     response = session.get(url)
     json_data = read_json(response)
     logging.debug(f"Raw extracted data from {url}:")
     logging.debug(json_data)
     extracted_json_by_json_query = extract_json(session, field_extractors.values(), json_data, engine)
+    field_values = {name: extracted_json_by_json_query[query] for (name, query) in field_extractors.items()}
+    # (We intentionally save even on unsuccessful extractions, because it's valuable data)
+    save_data_on_s3(station_id, json_data, field_values)
     # Make sure all field extraction was successful
-    if all(extracted_json_by_json_query.values()):
-        field_values = {name: extracted_json_by_json_query[query] for (name, query) in field_extractors.items()}
+    if all(field_values.values()):
         logging.debug(field_values)
         title = format_string.format(**field_values)
         playing_items = [PlayingItem(type='song', title=title)]
@@ -72,17 +75,22 @@ def query_java_jsonpath_api(session, jsonpath_queries, json_str):
     return {jsonpath_query: json.loads(result) if result else "" for jsonpath_query, result in results.items()}
 
 
-def save_data_on_s3(url, json_data, extracted_data):
+def save_data_on_s3(station_id, json_data, extracted_data):
     if settings.s3.enabled:
-        s3 = boto3.resource('s3', endpoint_url=settings.s3.endpoint_url)
-        domain = urlparse(url).netloc
-        timestamp = int(time.time())
-        filenames = ("data.json", "extracted.json")
-        content = (json_data, extracted_data)
-        bucket = s3.Bucket(settings.s3.bucket_name)
-        for filename, data in zip(filenames, content):
-            key = f"json/{domain}/{timestamp}/{filename}"
-            bucket.put_object(
-                Key=key,
-                Body=json.dumps(data)
-            )
+        try:
+            s3 = boto3.resource('s3', endpoint_url=settings.s3.endpoint_url)
+            timestamp = int(time.time())
+            filenames = ("data.json", "extracted.json")
+            content = (json_data, extracted_data)
+            bucket = s3.Bucket(settings.s3.bucket_name)
+            for filename, data in zip(filenames, content):
+                key = f"json/{station_id}/{timestamp}/{filename}"
+                bucket.put_object(
+                    Key=key,
+                    Body=json.dumps(data)
+                )
+        except botocore.exceptions.ClientError as e:
+            # Don't error out here, just log a warning.
+            # Aggregation was still successful, we just can't gather stats.
+            logging.warning("Could not save aggregation results on S3")
+            logging.exception(e)

--- a/src/aggregators/jsonpath_aggregator.py
+++ b/src/aggregators/jsonpath_aggregator.py
@@ -77,6 +77,7 @@ def query_java_jsonpath_api(session, jsonpath_queries, json_str):
 
 def save_data_on_s3(station_id, json_data, extracted_data):
     if settings.s3.enabled:
+        logging.info("Saving aggregated data to S3")
         try:
             s3 = boto3.resource('s3', endpoint_url=settings.s3.endpoint_url)
             timestamp = int(time.time())
@@ -89,6 +90,11 @@ def save_data_on_s3(station_id, json_data, extracted_data):
                     Key=key,
                     Body=json.dumps(data)
                 )
+        except botocore.exceptions.BotoCoreError as e:
+            # Don't error out here, just log a warning.
+            # Aggregation was still successful, we just can't gather stats.
+            logging.warning("Could not save aggregation results on S3")
+            logging.exception(e)
         except botocore.exceptions.ClientError as e:
             # Don't error out here, just log a warning.
             # Aggregation was still successful, we just can't gather stats.

--- a/src/base/config/__init__.py
+++ b/src/base/config/__init__.py
@@ -15,7 +15,7 @@ print(f"Using config path {ROOT_PATH_FOR_DYNACONF}")
 
 settings = WatchedConf(
         envvar_prefix="DYNACONF",
-        # settings_files=['logging.ini'], # FIXME: causes exception
+        settings_files=['config.yaml'],
         includes=['stations/*.yaml', 'stations/*/*.yaml'],
         root_path=ROOT_PATH_FOR_DYNACONF,
         merge_enabled=True
@@ -23,6 +23,7 @@ settings = WatchedConf(
 
 
 def load_logging_config(path=DEFAULT_CONFIG_PATH):
+    # FIXME: should load using dynaconf/generic conf loading, but causes exception rn 🤷
     # Using print() since logging not set up yet
     print(f"Loading config from '{path}'")
     config_file = os.path.join(path, 'logging.ini')


### PR DESCRIPTION
Save both original payload and extraction results to S3 when using jsonpath aggregator.

The idea is to build a dataset of successful/unsuccessful extractions for DS/ML.