### PR TITLE
Serialise all aggregation results to S3...

### DIFF
--- a/src/aggregators/__init__.py
+++ b/src/aggregators/__init__.py
@@ -1,6 +1,8 @@
+from enum import Enum
 import importlib
 import functools
 import logging
+from typing import Union
 from dataclasses import dataclass, field
 
 from base import config
@@ -10,7 +12,22 @@ from base import config
 class PlayingItem():
     type: str
     title: str
-    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class Source():
+    type: str
+    data: Union[dict, str, None]
+
+
+@dataclass
+class AggregationResult():
+    items: list[PlayingItem]
+    sources: list[Source]
+
+    @staticmethod
+    def empty(sources: list[Source]):
+        return AggregationResult(items=[], sources=sources)
 
 
 @dataclass

--- a/src/aggregators/fip.py
+++ b/src/aggregators/fip.py
@@ -1,5 +1,5 @@
 from string import Template
-from aggregators import PlayingItem
+from aggregators import AggregationResult, PlayingItem, Source
 
 # FIXME: pass these ids as config values straight from the config file
 stations = {
@@ -42,7 +42,7 @@ def fetch(session, request_type, station_id):
     now_playing_list = json_body['data']['nowList']
     songs = [item['song'] for item in now_playing_list]
     playing_items = [
-        PlayingItem(type='song', title=build_title(song), metadata=song)
+        PlayingItem(type='song', title=build_title(song))
         for song in songs
     ]
-    return playing_items
+    return AggregationResult(items=playing_items, sources=[Source(type='json', data=json_body)])

--- a/src/aggregators/france_inter.py
+++ b/src/aggregators/france_inter.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from aggregators import PlayingItem
+from aggregators import AggregationResult, PlayingItem, Source
 import logging
 
 url = "https://www.franceinter.fr/programmes"
@@ -28,5 +28,6 @@ def fetch_url(session, url):
                 title = item['conceptTitle']
             else:
                 title = item['conceptTitle'] + " - " + item['expressionTitle']
-            return [PlayingItem('programme', title, item)]
-    return []
+            items = [PlayingItem('programme', title)]
+            return AggregationResult(items, sources=[Source('json', playlist)])
+    return AggregationResult.empty(sources=[Source('json', playlist)])

--- a/src/aggregators/jsonpath_aggregator.py
+++ b/src/aggregators/jsonpath_aggregator.py
@@ -9,7 +9,7 @@ import logging
 import time
 
 from base.config import settings
-from aggregators import PlayingItem
+from aggregators import AggregationResult, PlayingItem, Source
 
 PYTHON_JSONPATH_NG_EXT = 'python-jsonpath-ng-ext'
 JAVA_JAYWAY = 'java-jayway'
@@ -29,12 +29,15 @@ def fetch(session, request_type: str, station_id: str, url: str, field_extractor
     # (We intentionally save even on unsuccessful extractions, because it's valuable data)
     save_data_on_s3(station_id, json_data, field_values)
     # Make sure all field extraction was successful
+    playing_items = []
     if all(field_values.values()):
         logging.debug(field_values)
         title = format_string.format(**field_values)
         playing_items = [PlayingItem(type='song', title=title)]
-        return playing_items
-    return []
+    return AggregationResult(
+        items=playing_items,
+        sources=[Source(type='json', data=json_data)]
+    )
 
 
 def read_json(response):

--- a/src/aggregators/plain_text_aggregator.py
+++ b/src/aggregators/plain_text_aggregator.py
@@ -1,8 +1,11 @@
-from aggregators import PlayingItem
+from aggregators import AggregationResult, PlayingItem, Source
 
 
 def fetch(session, request_type, url, encoding, item_type='song'):
     response = session.get(url)
     response.encoding = encoding
     title = response.text
-    return [PlayingItem(type=item_type, title=title)]
+    return AggregationResult(
+        items=[PlayingItem(type=item_type, title=title)],
+        sources=[Source(type='text', data=response.text)]
+    )

--- a/src/aggregators/radio_meuh.py
+++ b/src/aggregators/radio_meuh.py
@@ -1,4 +1,4 @@
-from aggregators import PlayingItem
+from aggregators import AggregationResult, PlayingItem, Source
 
 url = "https://www.radiomeuh.com/player/rtdata/tracks.json"
 
@@ -8,4 +8,7 @@ def fetch(session, request_type):
     data = response.json()
     song = data[0]
     title = song['artist'] + " - " + song['titre']
-    return [PlayingItem('song', title, song)]
+    return AggregationResult(
+        items=[PlayingItem('song', title)],
+        sources=[Source(type='json', data=data)]
+    )

--- a/src/aggregators/stream_aggregator.py
+++ b/src/aggregators/stream_aggregator.py
@@ -1,4 +1,4 @@
-from aggregators import PlayingItem
+from aggregators import AggregationResult, PlayingItem, Source
 
 import chardet
 import logging
@@ -7,8 +7,11 @@ from streamscrobbler import streamscrobbler
 
 def fetch(session, request_type: str, stream_url: str, encoding: str = None):
     stationinfo = streamscrobbler.get_server_info(stream_url)
+    items = []
+    sources = []
     if stationinfo['metadata']:
         metadata = stationinfo['metadata']
+        sources = [Source(type='stream_metadata', data=metadata)]
         try:
             song = metadata['song']
             # Looks like sometimes the library returns bytes instead of str...
@@ -20,7 +23,10 @@ def fetch(session, request_type: str, stream_url: str, encoding: str = None):
                     logging.info(f"Detected: {result}")
                     encoding = result['encoding']
                 song = song.decode(encoding)
-            return [PlayingItem(type='song', title=song)]
+            items = [PlayingItem(type='song', title=song)]
         except KeyError:
-            return []
-    return []
+            pass
+    return AggregationResult(
+        items=items,
+        sources=sources
+    )

--- a/src/aggregators/test/test_aggregators.py
+++ b/src/aggregators/test/test_aggregators.py
@@ -5,20 +5,14 @@ import aggregators
 session = requests_cache.CachedSession(backend='memory', expire_after=60)
 
 
-def test_fetch_returns_iterable(country_code, station_id, aggregator):
-    results = aggregator(session, 'now-playing')
-    iter(results)
-
-
-def test_fetch_returns_playing_items(country_code, station_id, aggregator):
-    results = aggregator(session, 'now-playing')
-    for item in results:
-        assert isinstance(item, aggregators.PlayingItem)
+def test_fetch_returns_aggregation_result(country_code, station_id, aggregator):
+    result = aggregator(session, 'now-playing')
+    assert isinstance(result, aggregators.AggregationResult)
 
 
 def test_fetch_has_required_fields(country_code, station_id, aggregator):
-    results = aggregator(session, 'now-playing')
-    for item in results:
+    result = aggregator(session, 'now-playing')
+    for item in result.items:
         assert (item.title is None or isinstance(item.title, str))
         assert isinstance(item.type, str)
         assert item.type in ('song', 'programme')

--- a/src/api/controllers/stations_controller.py
+++ b/src/api/controllers/stations_controller.py
@@ -54,8 +54,8 @@ def get_now_playing_by_country_code_and_station_id(namespace, slug):
             span.set_attribute('station_id', f'{namespace}/{slug}')
             span.set_attribute('namespace', namespace)
             span.set_attribute('slug', slug)
-            now_playing_items = aggregator(session, 'now-playing')
-        playing_item = next(iter(now_playing_items))
+            aggregation_result = aggregator(session, 'now-playing')
+        playing_item = next(iter(aggregation_result.items))
         return NowPlaying(type=playing_item.type, title=playing_item.title)
     except StopIteration:
         return {'title': "Could not fetch now playing information"}, 500

--- a/src/api/test/test_stations_controller.py
+++ b/src/api/test/test_stations_controller.py
@@ -13,14 +13,19 @@ from api.test import BaseTestCase
 class TestStationsController(BaseTestCase):
     """StationsController integration test stubs"""
 
-    def test_get_station_by_country_code_and_station_id(self):
+    def test_get_station_by_station_id(self):
         response = self.client.open(
             '/api/stations/{namespace}/{slug}'.format(namespace='fr', slug='radiomeuh'),
             method='GET')
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 
-
+    def test_get_now_playing_by_station_id(self):
+        response = self.client.open(
+            '/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='radiomeuh'),
+            method='GET')
+        self.assert200(response,
+                       'Response body is : ' + response.data.decode('utf-8'))
 
 if __name__ == '__main__':
     import unittest

--- a/src/base/json.py
+++ b/src/base/json.py
@@ -1,0 +1,10 @@
+import dataclasses
+import json
+
+
+class DataClassJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return o.__dict__
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
* Return richer `AggregationResult` object from aggregators, which provide the original source and type of aggregation result
* Save *all* aggregation results to S3, regardless of the source type.