### PR TITLE
Disable flask opentelemetry instrumentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,10 @@ decorator==5.0.9
 Deprecated==1.2.12
 dynaconf==3.1.4
 environs==9.3.2
+Flask==2.0.1
 googleapis-common-protos==1.53.0
 grpcio==1.38.0
+gunicorn==20.1.0
 idna==2.10
 inflection==0.5.1
 isodate==0.6.0
@@ -38,6 +40,7 @@ opentelemetry-api==1.3.0
 opentelemetry-exporter-otlp==1.3.0
 opentelemetry-exporter-otlp-proto-grpc==1.3.0
 opentelemetry-instrumentation==0.22b0
+opentelemetry-instrumentation-asgi==0.22b0
 opentelemetry-instrumentation-boto==0.22b0
 opentelemetry-instrumentation-botocore==0.22b0
 opentelemetry-instrumentation-flask==0.22b0

--- a/src/api/tracing.py
+++ b/src/api/tracing.py
@@ -1,36 +1,53 @@
 import logging
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+)
 from opentelemetry.launcher import configure_opentelemetry
-from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.urllib import URLLibInstrumentor
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+
 
 import os
 
 
-def configure_tracer(app):
-    if 'LS_SERVICE_NAME' not in os.environ:
-        logging.warning("'LS_SERVICE_NAME' undefined, cannot configure tracing")
-        return
-    if 'LS_ACCESS_TOKEN' not in os.environ:
-        logging.warning("'LS_ACCESS_TOKEN' undefined, cannot configure tracing")
-        return
+def configure_console_tracer():
+    provider = TracerProvider()
+    processor = SimpleSpanProcessor(ConsoleSpanExporter())
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
 
-    service_name = os.environ['LS_SERVICE_NAME']
-    lightstep_access_token = os.environ['LS_ACCESS_TOKEN']
-    configure_opentelemetry(
-      service_name=service_name,
-      access_token=lightstep_access_token,
-    )
+
+def configure_tracer(app):
+    if 'LS_SERVICE_NAME' not in os.environ or 'LS_ACCESS_TOKEN' not in os.environ:
+        if 'LS_SERVICE_NAME' not in os.environ:
+            logging.warning("'LS_SERVICE_NAME' undefined, cannot configure lightstep")
+        if 'LS_ACCESS_TOKEN' not in os.environ:
+            logging.warning("'LS_ACCESS_TOKEN' undefined, cannot configure lightstep")
+        logging.warning("Cannot configure lightstep, using console tracer provider")
+        configure_console_tracer()
+    else:
+        service_name = os.environ['LS_SERVICE_NAME']
+        lightstep_access_token = os.environ['LS_ACCESS_TOKEN']
+        configure_opentelemetry(
+          service_name=service_name,
+          access_token=lightstep_access_token,
+        )
     add_instrumentation(app)
     logging.info("Tracing is enabled.")
 
 
 def add_instrumentation(app):
-    FlaskInstrumentor().instrument_app(app.app)
+    # FIXME: doesn't work since aiohttp isn't ASGI-compatible
+    # app.app = OpenTelemetryMiddleware(app.app)
     RequestsInstrumentor().instrument(span_callback=set_cached_response_tag)
     URLLibInstrumentor().instrument()
     BotocoreInstrumentor().instrument()
+    return app
 
 
 def set_cached_response_tag(span, result):


### PR DESCRIPTION
Flask opentelemetry instrumentation doesn't work anymore since... well we're not using flask anymore.