### PR TITLE
Port to openapi, add examples, + tracing bugfix...

### DIFF
--- a/src/api/controllers/stations_controller.py
+++ b/src/api/controllers/stations_controller.py
@@ -92,7 +92,7 @@ async def get_station_by_country_code_and_station_id(namespace, slug):  # noqa: 
         return json_response(data={'title': "Station not found"}, status=404)
 
 
-def search(query):  # noqa: E501
+async def search(query):  # noqa: E501
     """Finds a station by name
 
     :param query: Search query

--- a/src/api/openapi/spec.yaml
+++ b/src/api/openapi/spec.yaml
@@ -71,6 +71,7 @@ paths:
         required: true
         schema:
           type: string
+          example: fr
       responses:
         200:
           description: successful operation
@@ -96,12 +97,14 @@ paths:
         required: true
         schema:
           type: string
+          example: fr
       - name: slug
         in: path
-        description: slug (short human-readable id) of a station
+        description: A short, human-readable identifier for a radio station, unique in a given namespace
         required: true
         schema:
           type: string
+          example: radiomeuh
       responses:
         200:
           description: successful operation
@@ -124,16 +127,18 @@ paths:
       parameters:
       - name: namespace
         in: path
-        description: Country code of a station
+        description: Namespace of a station
         required: true
         schema:
           type: string
+          example: fr
       - name: slug
         in: path
-        description: ID of a station
+        description: A short, human-readable identifier for a radio station, unique in a given namespace
         required: true
         schema:
           type: string
+          example: radiomeuh
       responses:
         200:
           description: successful operation

--- a/src/api/openapi/spec.yaml
+++ b/src/api/openapi/spec.yaml
@@ -1,222 +1,233 @@
----
-swagger: "2.0"
+openapi: 3.0.1
 info:
-  description: "Now Playing API."
-  version: "0.1.0"
-  title: "Now Playing API"
+  title: Now Playing API
+  description: Now Playing API.
   contact:
-    email: "jeremiejost@gmail.com"
-basePath: "/api"
+    email: jeremiejost@gmail.com
+  version: 0.1.0
+servers:
+- url: /api
 tags:
-- name: "stations"
-  description: "Find radio stations and what they're playing"
+- name: stations
+  description: Find radio stations and what they're playing
   externalDocs:
-    description: "Find out more"
-    url: "https://github.com/jjst/now-playing"
-schemes:
-- "https"
-- "http"
+    description: Find out more
+    url: https://github.com/jjst/now-playing
 paths:
   /search:
     get:
       tags:
-      - "stations"
-      summary: "Find a station by name"
-      operationId: "search"
-      produces:
-      - "application/json"
+      - stations
+      summary: Find a station by name
+      operationId: search
       parameters:
-      - name: "query"
-        in: "query"
-        description: "Search query"
+      - name: query
+        in: query
+        description: Search query
         required: true
-        type: "array"
-        items:
-          type: "string"
-        collectionFormat: "multi"
+        style: form
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/SearchResult"
-        "400":
-          description: "Invalid query"
-      x-swagger-router-controller: "api.controllers.stations_controller"
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResult'
+        400:
+          description: Invalid query
+          content: {}
+      x-openapi-router-controller: api.controllers.stations_controller
   /stations:
     get:
       tags:
-      - "stations"
-      summary: "List all stations"
-      description: "Gets all radio stations"
-      operationId: "get_stations"
-      produces:
-      - "application/json"
+      - stations
+      summary: List all stations
+      description: Gets all radio stations
+      operationId: get_stations
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/RadioStationList"
-      x-swagger-router-controller: "api.controllers.stations_controller"
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RadioStationList'
+      x-openapi-router-controller: api.controllers.stations_controller
   /stations/{namespace}:
     get:
       tags:
-      - "stations"
-      summary: "List all stations in a namespace"
-      description: "Gets all radio stations in a namespace"
-      operationId: "get_stations_by_country_code"
-      produces:
-      - "application/json"
+      - stations
+      summary: List all stations in a namespace
+      description: Gets all radio stations in a namespace
+      operationId: get_stations_by_country_code
       parameters:
-      - name: "namespace"
-        in: "path"
-        description: "Country code of a station"
+      - name: namespace
+        in: path
+        description: Country code of a station
         required: true
-        type: "string"
+        schema:
+          type: string
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/RadioStationList"
-        "404":
-          description: "Station not found"
-      x-swagger-router-controller: "api.controllers.stations_controller"
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RadioStationList'
+        404:
+          description: Station not found
+          content: {}
+      x-openapi-router-controller: api.controllers.stations_controller
   /stations/{namespace}/{slug}:
     get:
       tags:
-      - "stations"
-      summary: "Get radio station information"
-      description: "Returns a radio station"
-      operationId: "get_station_by_country_code_and_station_id"
-      produces:
-      - "application/json"
+      - stations
+      summary: Get radio station information
+      description: Returns a radio station
+      operationId: get_station_by_country_code_and_station_id
       parameters:
-      - name: "namespace"
-        in: "path"
-        description: "Namespace of a station"
+      - name: namespace
+        in: path
+        description: Namespace of a station
         required: true
-        type: "string"
-      - name: "slug"
-        in: "path"
-        description: "slug (short human-readable id) of a station"
+        schema:
+          type: string
+      - name: slug
+        in: path
+        description: slug (short human-readable id) of a station
         required: true
-        type: "string"
+        schema:
+          type: string
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/RadioStation"
-        "404":
-          description: "Station not found"
-      x-swagger-router-controller: "api.controllers.stations_controller"
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RadioStation'
+        404:
+          description: Station not found
+          content: {}
+      x-openapi-router-controller: api.controllers.stations_controller
   /stations/{namespace}/{slug}/now-playing:
     get:
       tags:
-      - "stations"
-      summary: "Get now playing information for a given station"
-      description: "Returns what a radio station is currently playing. This will return a song or programme title."
-      operationId: "get_now_playing_by_country_code_and_station_id"
-      produces:
-      - "application/json"
+      - stations
+      summary: Get now playing information for a given station
+      description: Returns what a radio station is currently playing. This will return
+        a song or programme title.
+      operationId: get_now_playing_by_country_code_and_station_id
       parameters:
-      - name: "namespace"
-        in: "path"
-        description: "Country code of a station"
+      - name: namespace
+        in: path
+        description: Country code of a station
         required: true
-        type: "string"
-      - name: "slug"
-        in: "path"
-        description: "ID of a station"
+        schema:
+          type: string
+      - name: slug
+        in: path
+        description: ID of a station
         required: true
-        type: "string"
+        schema:
+          type: string
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/NowPlaying"
-        "404":
-          description: "now-playing information for this station is not available"
-      x-swagger-router-controller: "api.controllers.stations_controller"
-definitions:
-  SearchResult:
-    type: "object"
-    required:
-    - "items"
-    properties:
-      items:
-        type: "array"
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NowPlaying'
+        404:
+          description: now-playing information for this station is not available
+          content: {}
+      x-openapi-router-controller: api.controllers.stations_controller
+components:
+  schemas:
+    SearchResult:
+      required:
+      - items
+      type: object
+      properties:
         items:
-          $ref: "#/definitions/RadioStation"
-  RadioStationList:
-    type: "object"
-    required:
-    - "items"
-    properties:
-      items:
-        type: "array"
+          type: array
+          items:
+            $ref: '#/components/schemas/RadioStation'
+    RadioStationList:
+      required:
+      - items
+      type: object
+      properties:
         items:
-          $ref: "#/definitions/RadioStation"
-  RadioStation:
-    type: "object"
-    required:
-    - "namespace"
-    - "slug"
-    - "id"
-    - "name"
-    properties:
-      id:
-        type: "string"
-      namespace:
-        type: "string"
-      slug:
-        type: "string"
-      name:
-        type: "string"
-      favicon:
-        type: "string"
-        format: uri
-      country_code:
-        type: "string"
-      streams:
-        type: array
-        items:
-          $ref: "#/definitions/Stream"
-    example:
-      namespace: "fr"
-      slug: "radiomeuh"
-      id: "fr/radiomeuh"
-      country_code: "fr"
-      name: "Radio Meuh"
-      streams:
-        - url: "http://radiomeuh.ice.infomaniak.ch/radiomeuh-128.mp3"
+          type: array
+          items:
+            $ref: '#/components/schemas/RadioStation'
+    RadioStation:
+      required:
+      - id
+      - name
+      - namespace
+      - slug
+      type: object
+      properties:
+        id:
+          type: string
+        namespace:
+          type: string
+        slug:
+          type: string
+        name:
+          type: string
+        favicon:
+          type: string
+          format: uri
+        country_code:
+          type: string
+        streams:
+          type: array
+          items:
+            $ref: '#/components/schemas/Stream'
+      example:
+        namespace: fr
+        slug: radiomeuh
+        id: fr/radiomeuh
+        country_code: fr
+        name: Radio Meuh
+        streams:
+        - url: http://radiomeuh.ice.infomaniak.ch/radiomeuh-128.mp3
           bitrate_kbps: 128
-  Stream:
-    type: "object"
-    required:
-    - "url"
-    properties:
-      url:
-        type: "string"
-        format: url
-      quality:
-        type: "string"
-      bitrate_kbps:
-        type: integer
-        format: int32
-    example:
-      url: "http://radiomeuh.ice.infomaniak.ch/radiomeuh-128.mp3"
-      bitrate_kbps: 128
-  NowPlaying:
-    type: "object"
-    properties:
-      title:
-        type: "string"
-      type:
-        type: "string"
-        enum:
+    Stream:
+      required:
+      - url
+      type: object
+      properties:
+        url:
+          type: string
+          format: url
+        quality:
+          type: string
+        bitrate_kbps:
+          type: integer
+          format: int32
+      example:
+        url: http://radiomeuh.ice.infomaniak.ch/radiomeuh-128.mp3
+        bitrate_kbps: 128
+    NowPlaying:
+      type: object
+      properties:
+        title:
+          type: string
+        type:
+          type: string
+          enum:
           - song
           - programme
-      metadata:
-        type: object
-    example:
-      title: "Europe - The Final Countdown"
-      type: "song"
+        metadata:
+          type: object
+          properties: {}
+      example:
+        title: Europe - The Final Countdown
+        type: song

--- a/src/api/tracing/aiohttp.py
+++ b/src/api/tracing/aiohttp.py
@@ -7,19 +7,22 @@ USER_AGENT = 'User-Agent'
 @middleware
 async def middleware(request, handler):
     route = request.match_info.route
-    span_name = f"{route.method} {route.resource.canonical}"
-    tracer = trace.get_tracer(__name__)
-    with tracer.start_as_current_span(span_name) as span:
-        span.set_attribute('span.kind', 'server')
-        span.set_attribute('http.route', route.resource.canonical)
-        span.set_attribute('http.host', request.host)
-        span.set_attribute('http.method', route.method)
-        span.set_attribute('http.target', request.rel_url)
-        if USER_AGENT in request.headers:
-            span.set_attribute('http.user_agent', request.headers[USER_AGENT])
-        resp = await handler(request)
-        span.set_attribute('http.status_code', resp.status)
-    return resp
+    if route.resource:
+        span_name = f"{route.method} {route.resource.canonical}"
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span(span_name) as span:
+            span.set_attribute('span.kind', 'server')
+            span.set_attribute('http.route', route.resource.canonical)
+            span.set_attribute('http.host', request.host)
+            span.set_attribute('http.method', route.method)
+            span.set_attribute('http.target', request.rel_url)
+            if USER_AGENT in request.headers:
+                span.set_attribute('http.user_agent', request.headers[USER_AGENT])
+            resp = await handler(request)
+            span.set_attribute('http.status_code', resp.status)
+        return resp
+    else:
+        return await handler(request)
 
 
 def instrument_aiohttp_app(app):


### PR DESCRIPTION
* Port api spec to openapi 3
* Add examples to queries in spec
* Fix tracing bug: if a route doesn't exist and would lead to a 404, the tracing middleware didn't handle and would cause the app to crash and return 500.