### PR TITLE
Fix response caching bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.9"
 services:
   redis:
-    image: "redis:alpine"
+    image: "redis:6.2.4-alpine"
     ports:
       - "6379:6379"

--- a/src/api/response_cache.py
+++ b/src/api/response_cache.py
@@ -43,7 +43,11 @@ class ResponseCache():
                 raise ValueError("Only one of 'expire_in' or 'expire_at' should be provided as argument")
             current_span = trace.get_current_span()
             new_hashed_response = xxhash.xxh32_digest(response)
-            old_hashed_response = self.redis_client.getset(key_for(station, 'response-hash'), new_hashed_response)
+            old_hashed_response = self.redis_client.getset(
+                key_for(station, 'response-hash'),
+                new_hashed_response,
+                ex=self.default_ttl_seconds_if_changed
+            )
             if expire_in:
                 ttl_seconds = expire_in
             elif expire_at:

--- a/src/api/response_cache.py
+++ b/src/api/response_cache.py
@@ -1,10 +1,11 @@
 import logging
 import redis
 import xxhash
-from datetime import datetime
+import datetime
 from typing import Optional
 from opentelemetry import trace
 
+from base.utils import monkeypatch_method
 from base.config import settings
 from base.stations import RadioStationInfo
 
@@ -12,6 +13,39 @@ response_prefix = "response"
 response_hash_prefix = "response-hash"
 
 tracer = trace.get_tracer(__name__)
+
+
+@monkeypatch_method(redis.Redis)
+def set(self, name, value,
+        ex=None, px=None, nx=False, xx=False, keepttl=False, get=False):
+    """
+    Monkey-patch redis-py's set() to add support for Redis 6.2's 'GET'
+    parameter.
+    """
+    pieces = [name, value]
+    if ex is not None:
+        pieces.append('EX')
+        if isinstance(ex, datetime.timedelta):
+            ex = int(ex.total_seconds())
+        pieces.append(ex)
+    if px is not None:
+        pieces.append('PX')
+        if isinstance(px, datetime.timedelta):
+            px = int(px.total_seconds() * 1000)
+        pieces.append(px)
+
+    if nx:
+        pieces.append('NX')
+    if xx:
+        pieces.append('XX')
+
+    if keepttl:
+        pieces.append('KEEPTTL')
+
+    if get:
+        pieces.append('GET')
+
+    return self.execute_command('SET', *pieces)
 
 
 def key_for(station, prefix):
@@ -37,21 +71,22 @@ class ResponseCache():
                 return response
 
     def set(self, station: RadioStationInfo, response: str,
-            expire_in: Optional[int] = None, expire_at: Optional[datetime] = None):
+            expire_in: Optional[int] = None, expire_at: Optional[datetime.datetime] = None):
         with tracer.start_as_current_span("set_cached_response"):
             if expire_in and expire_at:
                 raise ValueError("Only one of 'expire_in' or 'expire_at' should be provided as argument")
             current_span = trace.get_current_span()
             new_hashed_response = xxhash.xxh32_digest(response)
-            old_hashed_response = self.redis_client.getset(
+            old_hashed_response = self.redis_client.set(
                 key_for(station, 'response-hash'),
                 new_hashed_response,
-                ex=self.default_ttl_seconds_if_changed
+                ex=self.default_ttl_seconds_if_changed,
+                get=True
             )
             if expire_in:
                 ttl_seconds = expire_in
             elif expire_at:
-                ttl_seconds = max(self.default_ttl_seconds, int((expire_at - datetime.now()).total_seconds()))
+                ttl_seconds = max(self.default_ttl_seconds, int((expire_at - datetime.datetime.now()).total_seconds()))
             elif old_hashed_response and new_hashed_response != old_hashed_response:
                 ttl_seconds = self.default_ttl_seconds_if_changed
             else:

--- a/src/api/test/test_response_cache.py
+++ b/src/api/test/test_response_cache.py
@@ -42,8 +42,12 @@ def test_set_uses_default_ttl_if_no_response_hash():
     response_cache.redis_client = MagicMock()
     response_cache.redis_client.set = MagicMock(return_value=None)
     response_cache.set(station, response)
-    response_cache.redis_client.set.assert_any_call('response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True)
-    response_cache.redis_client.set.assert_any_call('response:fr/radiomeuh', 'test-response', ex=1)
+    response_cache.redis_client.set.assert_any_call(
+        'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
+    )
+    response_cache.redis_client.set.assert_any_call(
+        'response:fr/radiomeuh', 'test-response', ex=1
+    )
 
 
 def test_set_uses_default_ttl_if_response_unchanged():
@@ -51,8 +55,12 @@ def test_set_uses_default_ttl_if_response_unchanged():
     hashed_response = xxhash.xxh32_digest(response)
     response_cache.redis_client.set = MagicMock(return_value=hashed_response)
     response_cache.set(station, response)
-    response_cache.redis_client.set.assert_any_call('response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True)
-    response_cache.redis_client.set.assert_any_call('response:fr/radiomeuh', 'test-response', ex=1)
+    response_cache.redis_client.set.assert_any_call(
+        'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
+    )
+    response_cache.redis_client.set.assert_any_call(
+        'response:fr/radiomeuh', 'test-response', ex=1
+    )
 
 
 def test_set_uses_ttl_if_changed_if_response_changed():
@@ -60,5 +68,9 @@ def test_set_uses_ttl_if_changed_if_response_changed():
     hashed_response = xxhash.xxh32_digest('old-response')
     response_cache.redis_client.set = MagicMock(return_value=hashed_response)
     response_cache.set(station, response)
-    response_cache.redis_client.set.assert_any_call('response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True)
-    response_cache.redis_client.set.assert_any_call('response:fr/radiomeuh', 'test-response', ex=5)
+    response_cache.redis_client.set.assert_any_call(
+        'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
+    )
+    response_cache.redis_client.set.assert_any_call(
+        'response:fr/radiomeuh', 'test-response', ex=5
+    )

--- a/src/base/utils.py
+++ b/src/base/utils.py
@@ -1,0 +1,6 @@
+
+def monkeypatch_method(cls):
+    def decorator(func):
+        setattr(cls, func.__name__, func)
+        return func
+    return decorator


### PR DESCRIPTION
The response cache stored a hash for the current station response indefinitely. It then uses that hash value to compare it against the current hash response, to determine for how long to TTL the current response.

The idea is as follows: if the current hash is the same as the previous hash, then the response (current playing track) didn't change, and thus we want a short TTL to detect a track change. If the response did just change though, we had a track change so we can affort a longer TTL.

The problem is this doesn't work if we store the response hash indefinitely. If we fetch info from a domain at T and cache the response hash, then query it again at T+30mins, the response hashes will be different, but that doesn't say there was a track change recently, it just says there was a track change during the last 30 mins... which isn't surprising. The track could then change 2 seconds after we fetch the info.

Address this by adding a ttl to the response-hash. We cache the response-hash for as long as we'd cache the response if we think we detected a track change.