### PR TITLE
Migrate to aioredis, return Cache-Control header even for cached response

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,7 @@
 aioboto3==9.0.0
 aiohttp==3.7.4.post0
 aiohttp-jinja2==1.4.2
+aioredis==2.0.0b1
 APScheduler==3.7.0
 asgiref==3.3.4
 async-timeout==3.0.1
@@ -61,7 +62,6 @@ python-dateutil==2.6.0
 python-dotenv==0.17.1
 pytz==2021.1
 PyYAML==5.4.1
-redis==3.5.3
 requests==2.25.1
 requests-cache==0.6.4
 streamscrobbler @ git+https://github.com/Horrendus/streamscrobbler-python@ec8fd4e1549b7cba25833950aa565b17700453e0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+asynctest==0.13.0
 coverage>=4.0.3
 pluggy>=0.3.1
 py>=1.4.31

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,5 +1,7 @@
 import connexion
 
+import aioredis
+
 from api import encoder
 from api.tracing import configure_tracer
 from api.cors import install_cors_middleware
@@ -14,3 +16,16 @@ def create_app():
 
     configure_tracer(app)
     return app
+
+
+async def create_redis_pool(app):
+    """Create Redis connection pool"""
+    redis_url = app["redis_url"]
+    pool = await aioredis.from_url(redis_url)
+    app["redis_pool"] = pool
+
+
+async def close_redis_pool(app):
+    """Close Redis connection pool"""
+    pool = app["redis_client"]
+    await pool.close()

--- a/src/api/controllers/stations_controller.py
+++ b/src/api/controllers/stations_controller.py
@@ -48,7 +48,7 @@ async def get_now_playing_by_country_code_and_station_id(namespace, slug):
     except KeyError:
         return json_response(data={'title': "Station not found"}, status=404)
     try:
-        cached_response = response_cache.get(station)
+        cached_response = await response_cache.get(station)
     except CacheError as e:
         # Log error, but we can proceed without caching with degraded performance
         cached_response = None
@@ -91,7 +91,7 @@ async def get_now_playing_by_country_code_and_station_id(namespace, slug):
     response = json.dumps(data, cls=JSONEncoder)
     actual_cache_expiry_seconds = None
     try:
-        actual_cache_expiry_seconds = response_cache.set(station, response, expire_at=cache_expiry)
+        actual_cache_expiry_seconds = await response_cache.set(station, response, expire_at=cache_expiry)
     except CacheError as e:
         # Log error, but we can proceed without caching with degraded performance
         logging.exception(e)

--- a/src/api/controllers/stations_controller.py
+++ b/src/api/controllers/stations_controller.py
@@ -1,4 +1,5 @@
 import asyncio
+import connexion
 import json
 import logging
 from aiohttp.web import Response, json_response

--- a/src/api/response_cache.py
+++ b/src/api/response_cache.py
@@ -1,4 +1,4 @@
-import redis
+import aioredis
 import xxhash
 import datetime
 from typing import Optional
@@ -14,7 +14,7 @@ response_hash_prefix = "response-hash"
 tracer = trace.get_tracer(__name__)
 
 
-@monkeypatch_method(redis.Redis)
+@monkeypatch_method(aioredis.Redis)
 def set(self, name, value,
         ex=None, px=None, nx=False, xx=False, keepttl=False, get=False):
     """
@@ -57,35 +57,35 @@ class CacheError(Exception):
 
 class ResponseCache():
     def __init__(self, settings=settings):
-        self.redis_client = redis.from_url(settings.redis.url, **settings.redis.args)
+        self.redis_client = aioredis.from_url(settings.redis.url, **settings.redis.args)
         self.default_ttl_seconds = settings.response_cache.default_ttl_seconds
         self.default_ttl_seconds_if_changed = settings.response_cache.default_ttl_seconds_if_changed
 
-    def get(self, station: RadioStationInfo) -> Optional[str]:
+    async def get(self, station: RadioStationInfo) -> Optional[str]:
         with tracer.start_as_current_span("get_cached_response") as span:
             try:
-                response = self.redis_client.get(key_for(station, 'response'))
-            except redis.exceptions.ConnectionError as e:
+                response = await self.redis_client.get(key_for(station, 'response'))
+            except aioredis.exceptions.ConnectionError as e:
                 raise CacheError("Error connecting to Redis. Cannot get cached response.") from e
             else:
                 span.set_attribute('cache_hit', (response is not None))
                 return response
 
-    def set(self, station: RadioStationInfo, response: str,
-            expire_in: Optional[int] = None, expire_at: Optional[datetime.datetime] = None) -> int:
+    async def set(self, station: RadioStationInfo, response: str,
+                  expire_in: Optional[int] = None, expire_at: Optional[datetime.datetime] = None) -> int:
         with tracer.start_as_current_span("set_cached_response"):
             if expire_in and expire_at:
                 raise ValueError("Only one of 'expire_in' or 'expire_at' should be provided as argument")
             current_span = trace.get_current_span()
             new_hashed_response = xxhash.xxh32_digest(response)
             try:
-                old_hashed_response = self.redis_client.set(
+                old_hashed_response = await self.redis_client.set(
                     key_for(station, 'response-hash'),
                     new_hashed_response,
                     ex=self.default_ttl_seconds_if_changed,
                     get=True
                 )
-            except redis.exceptions.ConnectionError as e:
+            except aioredis.exceptions.ConnectionError as e:
                 raise CacheError("Error connecting to Redis. Cannot set cached response.") from e
             if expire_in:
                 ttl_seconds = expire_in
@@ -97,7 +97,7 @@ class ResponseCache():
                 ttl_seconds = self.default_ttl_seconds
             current_span.add_event("determine_cached_response_ttl", attributes={'ttl_seconds': ttl_seconds})
             try:
-                self.redis_client.set(key_for(station, 'response'), response, ex=ttl_seconds)
-            except redis.exceptions.ConnectionError as e:
+                await self.redis_client.set(key_for(station, 'response'), response, ex=ttl_seconds)
+            except aioredis.exceptions.ConnectionError as e:
                 raise CacheError("Error connecting to Redis. Cannot set cached response.") from e
             return ttl_seconds

--- a/src/api/test/test_response_cache.py
+++ b/src/api/test/test_response_cache.py
@@ -2,6 +2,7 @@ from api.response_cache import ResponseCache, CacheError
 from base import stations
 
 import aioredis
+from asynctest.mock import CoroutineMock
 from unittest.mock import Mock, MagicMock
 import xxhash
 from datetime import datetime, timedelta
@@ -21,7 +22,7 @@ station = stations.get('fr', 'radiomeuh')
 async def test_set_raises_cacheerror_if_cant_connect_to_redis():
     err = aioredis.exceptions.ConnectionError("Can't connect")
     response_cache.redis_client = MagicMock()
-    response_cache.redis_client.set = MagicMock(side_effect=err)
+    response_cache.redis_client.set = CoroutineMock(side_effect=err)
     with pytest.raises(CacheError):
         await response_cache.set(station, response)
 
@@ -29,14 +30,14 @@ async def test_set_raises_cacheerror_if_cant_connect_to_redis():
 async def test_get_raises_cacheerror_if_cant_connect_to_redis():
     err = aioredis.exceptions.ConnectionError("Can't connect")
     response_cache.redis_client = MagicMock()
-    response_cache.redis_client.get = MagicMock(side_effect=err)
+    response_cache.redis_client.get = CoroutineMock(side_effect=err)
     with pytest.raises(CacheError):
         await response_cache.get(station)
 
 
 async def test_set_uses_expire_at_if_provided():
     response_cache.redis_client = MagicMock()
-    response_cache.redis_client.set = MagicMock(return_value=None)
+    response_cache.redis_client.set = CoroutineMock(return_value=None)
     expiry = datetime.now() + timedelta(seconds=20)
     await response_cache.set(station, response, expire_at=expiry)
     # FIXME: recipe for a transient failure if test runs slowly...
@@ -45,7 +46,7 @@ async def test_set_uses_expire_at_if_provided():
 
 async def test_set_uses_expire_in_if_provided():
     response_cache.redis_client = MagicMock()
-    response_cache.redis_client.set = MagicMock(return_value=None)
+    response_cache.redis_client.set = CoroutineMock(return_value=None)
     await response_cache.set(station, response, expire_in=20)
     response_cache.redis_client.set.assert_called_with('response:fr/radiomeuh', 'test-response', ex=20)
 
@@ -57,7 +58,7 @@ async def test_set_raises_valueerror_if_expire_in_and_expire_at_provided():
 
 async def test_set_uses_default_ttl_if_no_response_hash():
     response_cache.redis_client = MagicMock()
-    response_cache.redis_client.set = MagicMock(return_value=None)
+    response_cache.redis_client.set = CoroutineMock(return_value=None)
     await response_cache.set(station, response)
     response_cache.redis_client.set.assert_any_call(
         'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
@@ -70,7 +71,7 @@ async def test_set_uses_default_ttl_if_no_response_hash():
 async def test_set_uses_default_ttl_if_response_unchanged():
     response_cache.redis_client = MagicMock()
     hashed_response = xxhash.xxh32_digest(response)
-    response_cache.redis_client.set = MagicMock(return_value=hashed_response)
+    response_cache.redis_client.set = CoroutineMock(return_value=hashed_response)
     await response_cache.set(station, response)
     response_cache.redis_client.set.assert_any_call(
         'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
@@ -83,7 +84,7 @@ async def test_set_uses_default_ttl_if_response_unchanged():
 async def test_set_uses_ttl_if_changed_if_response_changed():
     response_cache.redis_client = MagicMock()
     hashed_response = xxhash.xxh32_digest('old-response')
-    response_cache.redis_client.set = MagicMock(return_value=hashed_response)
+    response_cache.redis_client.set = CoroutineMock(return_value=hashed_response)
     await response_cache.set(station, response)
     response_cache.redis_client.set.assert_any_call(
         'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True

--- a/src/api/test/test_response_cache.py
+++ b/src/api/test/test_response_cache.py
@@ -1,11 +1,11 @@
 from api.response_cache import ResponseCache, CacheError
 from base import stations
 
+import aioredis
 from unittest.mock import Mock, MagicMock
 import xxhash
 from datetime import datetime, timedelta
 import pytest
-import redis
 
 settings = Mock(
     redis=Mock(url='redis://localhost:6379/0', args={}),
@@ -18,47 +18,47 @@ response = 'test-response'
 station = stations.get('fr', 'radiomeuh')
 
 
-def test_set_raises_cacheerror_if_cant_connect_to_redis():
-    err = redis.exceptions.ConnectionError("Can't connect")
+async def test_set_raises_cacheerror_if_cant_connect_to_redis():
+    err = aioredis.exceptions.ConnectionError("Can't connect")
     response_cache.redis_client = MagicMock()
     response_cache.redis_client.set = MagicMock(side_effect=err)
     with pytest.raises(CacheError):
-        response_cache.set(station, response)
+        await response_cache.set(station, response)
 
 
-def test_get_raises_cacheerror_if_cant_connect_to_redis():
-    err = redis.exceptions.ConnectionError("Can't connect")
+async def test_get_raises_cacheerror_if_cant_connect_to_redis():
+    err = aioredis.exceptions.ConnectionError("Can't connect")
     response_cache.redis_client = MagicMock()
     response_cache.redis_client.get = MagicMock(side_effect=err)
     with pytest.raises(CacheError):
-        response_cache.get(station)
+        await response_cache.get(station)
 
 
-def test_set_uses_expire_at_if_provided():
+async def test_set_uses_expire_at_if_provided():
     response_cache.redis_client = MagicMock()
     response_cache.redis_client.set = MagicMock(return_value=None)
     expiry = datetime.now() + timedelta(seconds=20)
-    response_cache.set(station, response, expire_at=expiry)
+    await response_cache.set(station, response, expire_at=expiry)
     # FIXME: recipe for a transient failure if test runs slowly...
     response_cache.redis_client.set.assert_called_with('response:fr/radiomeuh', 'test-response', ex=19)
 
 
-def test_set_uses_expire_in_if_provided():
+async def test_set_uses_expire_in_if_provided():
     response_cache.redis_client = MagicMock()
     response_cache.redis_client.set = MagicMock(return_value=None)
-    response_cache.set(station, response, expire_in=20)
+    await response_cache.set(station, response, expire_in=20)
     response_cache.redis_client.set.assert_called_with('response:fr/radiomeuh', 'test-response', ex=20)
 
 
-def test_set_raises_valueerror_if_expire_in_and_expire_at_provided():
+async def test_set_raises_valueerror_if_expire_in_and_expire_at_provided():
     with pytest.raises(ValueError):
-        response_cache.set(station, response, expire_in=20, expire_at=datetime.now())
+        await response_cache.set(station, response, expire_in=20, expire_at=datetime.now())
 
 
-def test_set_uses_default_ttl_if_no_response_hash():
+async def test_set_uses_default_ttl_if_no_response_hash():
     response_cache.redis_client = MagicMock()
     response_cache.redis_client.set = MagicMock(return_value=None)
-    response_cache.set(station, response)
+    await response_cache.set(station, response)
     response_cache.redis_client.set.assert_any_call(
         'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
     )
@@ -67,11 +67,11 @@ def test_set_uses_default_ttl_if_no_response_hash():
     )
 
 
-def test_set_uses_default_ttl_if_response_unchanged():
+async def test_set_uses_default_ttl_if_response_unchanged():
     response_cache.redis_client = MagicMock()
     hashed_response = xxhash.xxh32_digest(response)
     response_cache.redis_client.set = MagicMock(return_value=hashed_response)
-    response_cache.set(station, response)
+    await response_cache.set(station, response)
     response_cache.redis_client.set.assert_any_call(
         'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
     )
@@ -80,11 +80,11 @@ def test_set_uses_default_ttl_if_response_unchanged():
     )
 
 
-def test_set_uses_ttl_if_changed_if_response_changed():
+async def test_set_uses_ttl_if_changed_if_response_changed():
     response_cache.redis_client = MagicMock()
     hashed_response = xxhash.xxh32_digest('old-response')
     response_cache.redis_client.set = MagicMock(return_value=hashed_response)
-    response_cache.set(station, response)
+    await response_cache.set(station, response)
     response_cache.redis_client.set.assert_any_call(
         'response-hash:fr/radiomeuh', xxhash.xxh32_digest(response), ex=5, get=True
     )

--- a/src/api/test/test_response_cache.py
+++ b/src/api/test/test_response_cache.py
@@ -31,6 +31,7 @@ async def test_get_raises_cacheerror_if_cant_connect_to_redis():
     err = aioredis.exceptions.ConnectionError("Can't connect")
     response_cache.redis_client = MagicMock()
     response_cache.redis_client.get = CoroutineMock(side_effect=err)
+    response_cache.redis_client.ttl = CoroutineMock(side_effect=err)
     with pytest.raises(CacheError):
         await response_cache.get(station)
 

--- a/src/api/test/test_stations_controller.py
+++ b/src/api/test/test_stations_controller.py
@@ -56,14 +56,13 @@ async def test_get_now_playing_by_station_id_uses_cache(loop, app, aiohttp_clien
 async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fresh_response(loop, app, aiohttp_client, redis_client):
     await redis_client.flushall()
     cache = ResponseCache()
-    r = await cache.get(stations.get('fr', 'fip'))
+    r, _ = await cache.get(stations.get('fr', 'fip'))
     assert r is None
     client = await aiohttp_client(app)
     response = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))
     assert 'Cache-Control' in response.headers
 
 
-@pytest.mark.xfail(reason="not yet implemented")
 async def test_get_now_playing_by_station_id_returns_cache_control_header_for_cached_response(loop, app, aiohttp_client, redis_client):
     client = await aiohttp_client(app)
     _ = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))

--- a/src/api/test/test_stations_controller.py
+++ b/src/api/test/test_stations_controller.py
@@ -1,10 +1,12 @@
 # coding: utf-8
+import aioredis
 import connexion
 import logging
 import pytest
 
 from api.response_cache import ResponseCache
 from base import stations
+from base.config import settings
 
 
 def create_app(loop):
@@ -12,6 +14,13 @@ def create_app(loop):
     app = connexion.AioHttpApp(__name__, specification_dir='../openapi/')
     app.add_api('spec.yaml')
     return app.app
+
+
+@pytest.fixture
+async def redis_client():
+    redis_client = aioredis.from_url(settings.redis.url, **settings.redis.args)
+    await redis_client.flushall()
+    return redis_client
 
 
 async def test_get_station_by_station_id(test_client):
@@ -26,7 +35,7 @@ async def test_get_now_playing_by_station_id(test_client):
     assert response.status == 200
 
 
-async def test_get_now_playing_by_station_id_uses_cache(test_client):
+async def test_get_now_playing_by_station_id_uses_cache(test_client, redis_client):
     client = await test_client(create_app)
     await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='radiomeuh'))
     response_cache = ResponseCache()
@@ -35,14 +44,14 @@ async def test_get_now_playing_by_station_id_uses_cache(test_client):
     assert cached_response is not None
 
 
-async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fresh_response(test_client):
+async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fresh_response(test_client, redis_client):
     client = await test_client(create_app)
     response = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))
     assert 'Cache-Control' in response.headers
 
 
 @pytest.mark.xfail(reason="not yet implemented")
-async def test_get_now_playing_by_station_id_returns_cache_control_header_for_cached_response(test_client):
+async def test_get_now_playing_by_station_id_returns_cache_control_header_for_cached_response(test_client, redis_client):
     client = await test_client(create_app)
     _ = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))
     response = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))

--- a/src/api/test/test_stations_controller.py
+++ b/src/api/test/test_stations_controller.py
@@ -9,7 +9,8 @@ from base import stations
 from base.config import settings
 
 
-def create_app(loop):
+@pytest.fixture
+def app():
     logging.getLogger('connexion.operation').setLevel('ERROR')
     app = connexion.AioHttpApp(__name__, specification_dir='../openapi/')
     app.add_api('spec.yaml')
@@ -17,42 +18,54 @@ def create_app(loop):
 
 
 @pytest.fixture
-async def redis_client():
+async def redis_client(loop):
+    # huge hack
+    # normally we should use the global app context to initialise and clean the redis connection
+    # however, connexion routing doesn't let us access the request and app context.
+    # in prod this doesn't currently cause issues, but in tests we use a different asyncio loop for each test
+    # and so we leave dangling redis connections bound to old loops.
+    import api.controllers.stations_controller as c
+    await c.response_cache.redis_client.close()
+    c.response_cache = ResponseCache()
     redis_client = aioredis.from_url(settings.redis.url, **settings.redis.args)
     await redis_client.flushall()
     return redis_client
 
 
-async def test_get_station_by_station_id(test_client):
-    client = await test_client(create_app)
+async def test_get_station_by_station_id(loop, app, aiohttp_client):
+    client = await aiohttp_client(app)
     response = await client.get('/api/stations/{namespace}/{slug}'.format(namespace='fr', slug='radiomeuh'))
     assert response.status == 200
 
 
-async def test_get_now_playing_by_station_id(test_client):
-    client = await test_client(create_app)
+async def test_get_now_playing_by_station_id(loop, app, aiohttp_client):
+    client = await aiohttp_client(app)
     response = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='radiomeuh'))
     assert response.status == 200
 
 
-async def test_get_now_playing_by_station_id_uses_cache(test_client, redis_client):
-    client = await test_client(create_app)
+async def test_get_now_playing_by_station_id_uses_cache(loop, app, aiohttp_client, redis_client):
+    client = await aiohttp_client(app)
     await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='radiomeuh'))
     response_cache = ResponseCache()
     station = stations.get('fr', 'radiomeuh')
-    cached_response = response_cache.get(station)
+    cached_response = await response_cache.get(station)
     assert cached_response is not None
 
 
-async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fresh_response(test_client, redis_client):
-    client = await test_client(create_app)
+async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fresh_response(loop, app, aiohttp_client, redis_client):
+    await redis_client.flushall()
+    cache = ResponseCache()
+    r = await cache.get(stations.get('fr', 'fip'))
+    assert r is None
+    client = await aiohttp_client(app)
     response = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))
     assert 'Cache-Control' in response.headers
 
 
 @pytest.mark.xfail(reason="not yet implemented")
-async def test_get_now_playing_by_station_id_returns_cache_control_header_for_cached_response(test_client, redis_client):
-    client = await test_client(create_app)
+async def test_get_now_playing_by_station_id_returns_cache_control_header_for_cached_response(loop, app, aiohttp_client, redis_client):
+    client = await aiohttp_client(app)
     _ = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))
     response = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))
     assert 'Cache-Control' in response.headers

--- a/src/api/test/test_stations_controller.py
+++ b/src/api/test/test_stations_controller.py
@@ -53,7 +53,8 @@ async def test_get_now_playing_by_station_id_uses_cache(loop, app, aiohttp_clien
     assert cached_response is not None
 
 
-async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fresh_response(loop, app, aiohttp_client, redis_client):
+async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fresh_response(
+        loop, app, aiohttp_client, redis_client):
     await redis_client.flushall()
     cache = ResponseCache()
     r, _ = await cache.get(stations.get('fr', 'fip'))
@@ -63,7 +64,8 @@ async def test_get_now_playing_by_station_id_returns_cache_control_header_for_fr
     assert 'Cache-Control' in response.headers
 
 
-async def test_get_now_playing_by_station_id_returns_cache_control_header_for_cached_response(loop, app, aiohttp_client, redis_client):
+async def test_get_now_playing_by_station_id_returns_cache_control_header_for_cached_response(
+        loop, app, aiohttp_client, redis_client):
     client = await aiohttp_client(app)
     _ = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))
     response = await client.get('/api/stations/{namespace}/{slug}/now-playing'.format(namespace='fr', slug='fip'))

--- a/src/api/tracing/__init__.py
+++ b/src/api/tracing/__init__.py
@@ -9,9 +9,9 @@ from opentelemetry.launcher import configure_opentelemetry
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.urllib import URLLibInstrumentor
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
-from opentelemetry.instrumentation.redis import RedisInstrumentor
 
 from api.tracing.aiohttp import instrument_aiohttp_app
+from api.tracing.aioredis import AioRedisInstrumentor
 
 
 import os
@@ -48,7 +48,7 @@ def add_instrumentation(app):
     RequestsInstrumentor().instrument(span_callback=set_cached_response_tag)
     URLLibInstrumentor().instrument()
     BotocoreInstrumentor().instrument()
-    RedisInstrumentor().instrument()
+    AioRedisInstrumentor().instrument()
     return app
 
 

--- a/src/api/tracing/aioredis/__init__.py
+++ b/src/api/tracing/aioredis/__init__.py
@@ -1,0 +1,120 @@
+# Borrowed from https://github.com/open-telemetry/opentelemetry-python-contrib/pull/569/files
+#
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Instrument `aioredis`_ to report Redis queries.
+
+There are two options for instrumenting code. The first option is to use the
+``opentelemetry-instrumentation`` executable which will automatically
+instrument your Redis client. The second is to programmatically enable
+instrumentation via the following code:
+
+.. _aioredis: https://pypi.org/project/aioredis/
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry.instrumentation.aioredis import AioRedisInstrumentor
+    import aioredis
+
+
+    # Instrument redis
+    AioRedisInstrumentor().instrument()
+
+    # This will report a span with the default settings
+    client = redis.StrictRedis(host="localhost", port=6379)
+    client.get("my-key")
+
+API
+---
+"""
+
+from typing import Collection
+
+import aioredis
+from wrapt import wrap_function_wrapper
+
+from opentelemetry import trace
+from api.tracing.aioredis.package import _instruments
+from api.tracing.aioredis.util import _format_command_args
+from api.tracing.aioredis.version import __version__
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.semconv.trace import (
+    DbSystemValues,
+    NetTransportValues,
+    SpanAttributes,
+)
+
+_DEFAULT_SERVICE = "redis"
+
+
+async def traced_execute(func, instance: aioredis.Redis, args, kwargs):
+    tracer = getattr(aioredis, "_opentelemetry_tracer")
+    query = _format_command_args(args)
+    name: str = ""
+    if len(args) > 0 and args[0]:
+        name = args[0].decode("utf-8")
+    else:
+        name = str(instance.db)
+    with tracer.start_as_current_span(
+        name, kind=trace.SpanKind.CLIENT
+    ) as span:
+        if span.is_recording():
+            span.set_attributes(
+                {
+                    SpanAttributes.DB_SYSTEM: DbSystemValues.REDIS.value,
+                    SpanAttributes.DB_STATEMENT: query,
+                    SpanAttributes.DB_NAME: instance.db,
+                    SpanAttributes.DB_REDIS_DATABASE_INDEX: instance.db,
+                }
+            )
+            span.set_attribute("db.redis.args_length", len(args))
+            if instance.address:
+                span.set_attributes(
+                    {
+                        SpanAttributes.NET_PEER_NAME: instance.address[0],
+                        SpanAttributes.NET_PEER_PORT: instance.address[1],
+                        SpanAttributes.NET_TRANSPORT: NetTransportValues.IP_TCP.value,
+                    }
+                )
+        return await func(*args, **kwargs)
+
+
+class AioRedisInstrumentor(BaseInstrumentor):
+    """An instrumentor for aioredis
+    See `BaseInstrumentor`
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        tracer_provider = kwargs.get("tracer_provider")
+        setattr(
+            aioredis,
+            "_opentelemetry_tracer",
+            trace.get_tracer(
+                __name__, __version__, tracer_provider=tracer_provider,
+            ),
+        )
+        wrap_function_wrapper(aioredis, "Redis.execute", traced_execute)
+
+    def _uninstrument(self, **kwargs):
+        unwrap(aioredis.Redis, "execute")

--- a/src/api/tracing/aioredis/package.py
+++ b/src/api/tracing/aioredis/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("aioredis >= 1.3, < 2.0",)

--- a/src/api/tracing/aioredis/util.py
+++ b/src/api/tracing/aioredis/util.py
@@ -1,0 +1,73 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Some utils used by the redis integration
+"""
+from opentelemetry.semconv.trace import (
+    DbSystemValues,
+    NetTransportValues,
+    SpanAttributes,
+)
+
+
+def _extract_conn_attributes(conn_kwargs):
+    """ Transform redis conn info into dict """
+    attributes = {
+        SpanAttributes.DB_SYSTEM: DbSystemValues.REDIS.value,
+    }
+    db = conn_kwargs.get("db", 0)
+    attributes[SpanAttributes.DB_NAME] = db
+    attributes[SpanAttributes.DB_REDIS_DATABASE_INDEX] = db
+    try:
+        attributes[SpanAttributes.NET_PEER_NAME] = conn_kwargs.get(
+            "host", "localhost"
+        )
+        attributes[SpanAttributes.NET_PEER_PORT] = conn_kwargs.get(
+            "port", 6379
+        )
+        attributes[
+            SpanAttributes.NET_TRANSPORT
+        ] = NetTransportValues.IP_TCP.value
+    except KeyError:
+        attributes[SpanAttributes.NET_PEER_NAME] = conn_kwargs.get("path", "")
+        attributes[
+            SpanAttributes.NET_TRANSPORT
+        ] = NetTransportValues.UNIX.value
+
+    return attributes
+
+
+def _format_command_args(args):
+    """Format command arguments and trim them as needed"""
+    value_max_len = 100
+    value_too_long_mark = "..."
+    cmd_max_len = 1000
+    length = 0
+    out = []
+    for arg in args:
+        cmd = str(arg)
+
+        if len(cmd) > value_max_len:
+            cmd = cmd[:value_max_len] + value_too_long_mark
+
+        if length + len(cmd) > cmd_max_len:
+            prefix = cmd[: cmd_max_len - length]
+            out.append("%s%s" % (prefix, value_too_long_mark))
+            break
+
+        out.append(cmd)
+        length += len(cmd)
+
+    return " ".join(out)

--- a/src/api/tracing/aioredis/version.py
+++ b/src/api/tracing/aioredis/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.23.dev0"


### PR DESCRIPTION
* Migrate to aioredis instead of py-redis
* return Cache-Control header even for cached response